### PR TITLE
Ensure state file is written when no posts are found

### DIFF
--- a/src/hemmatco_scraper/main.py
+++ b/src/hemmatco_scraper/main.py
@@ -21,6 +21,9 @@ def format_post(post: Post) -> Iterable[str]:
 
 def dispatch_posts(settings: Settings, posts: list[Post], state: State) -> None:
     if not posts:
+        # Ensure the state file exists so downstream cache steps have a
+        # concrete path even when no new posts are discovered.
+        state.save()
         logger.info("No new posts to dispatch")
         return
 


### PR DESCRIPTION
## Summary
- save the state file even when no new posts are dispatched so the cache path always exists

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68d7d4045640832596076f5a769622be