### PR TITLE
Ensure chronological dispatch order and add reset option

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 0,12 * * *'
   workflow_dispatch:
+    inputs:
+      reset_state:
+        description: 'Set to true to clear processed posts before scraping'
+        required: false
+        default: 'false'
 
 jobs:
   scrape:
@@ -38,6 +43,7 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           TELEGRAM_TOPIC_ID: ${{ secrets.TELEGRAM_TOPIC_ID }}
+          RESET_STATE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reset_state || 'false' }}
         run: python -m hemmatco_scraper
 
       - name: Save processed posts cache

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project scrapes the Hemmatco blog, collects direct links to all images insi
 
 - Crawls all 48 archive pages of [`https://hemmatco.com/blog/`](https://hemmatco.com/blog/).
 - Visits every post (10 posts per page) and extracts the URLs of every `<img>` element within the article body.
-- On the first run it processes the entire history starting from the oldest posts and waits 5 seconds between each request to respect the target website.
+- On the first run it processes the entire history starting from the oldest posts (page 48) and waits 5 seconds between each request to respect the target website.
 - Subsequent runs only send newly discovered posts and use a shorter (configurable) delay.
 - Sends the discovered image links to a Telegram forum topic via a bot.
 - Persists the list of processed posts in `state/processed_posts.json` so each post is sent only once.
@@ -46,6 +46,7 @@ This project scrapes the Hemmatco blog, collects direct links to all images insi
 | `INITIAL_POST_SLEEP_SECONDS` | `5` | Delay between posts during the very first full crawl. |
 | `SUBSEQUENT_POST_SLEEP_SECONDS` | `1` | Delay between posts on later runs. |
 | `STATE_FILE` | `state/processed_posts.json` | Location of the JSON state file. |
+| `RESET_STATE` | `false` | When `true`, clears the cached list of processed posts before running (useful for tests). |
 | `SCRAPER_USER_AGENT` | `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36` | Custom User-Agent header for requests. |
 
 ## GitHub Actions automation
@@ -57,6 +58,8 @@ The repository includes `.github/workflows/scrape.yml`, which runs twice a day (
 - `TELEGRAM_TOPIC_ID` (optional)
 
 The workflow preserves `state/processed_posts.json` across runs using the GitHub Actions cache. Do not delete the workflow cache if you want to keep the history of processed posts.
+
+When you trigger the workflow manually you can optionally set the `reset_state` input to `true` to clear the cached history before scraping. This is useful for test runs where you want to resend every post from the beginning.
 
 ## Telegram permissions
 

--- a/src/hemmatco_scraper/config.py
+++ b/src/hemmatco_scraper/config.py
@@ -21,6 +21,7 @@ class Settings:
     telegram_chat_id: str
     telegram_topic_id: Optional[int]
     user_agent: str
+    reset_state: bool
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -43,6 +44,7 @@ class Settings:
                 "Chrome/123.0.0.0 Safari/537.36"
             ),
         )
+        reset_state = os.getenv("RESET_STATE", "").strip().lower() in {"1", "true", "yes", "on"}
 
         return cls(
             base_url=base_url,
@@ -56,6 +58,7 @@ class Settings:
             telegram_chat_id=telegram_chat_id,
             telegram_topic_id=telegram_topic_id,
             user_agent=user_agent,
+            reset_state=reset_state,
         )
 
 

--- a/src/hemmatco_scraper/main.py
+++ b/src/hemmatco_scraper/main.py
@@ -53,6 +53,9 @@ def dispatch_posts(settings: Settings, posts: list[Post], state: State) -> None:
 def main() -> None:
     settings = Settings.from_env()
     state = State(settings.state_file)
+    if settings.reset_state:
+        logger.info("RESET_STATE enabled – clearing processed posts cache")
+        state.clear()
     session = create_session(settings)
     posts = collect_new_posts(session, settings, state)
     dispatch_posts(settings, posts, state)

--- a/src/hemmatco_scraper/scraper.py
+++ b/src/hemmatco_scraper/scraper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import Iterable, Iterator, List
+from typing import Iterable, Iterator, List, Mapping
 from urllib.parse import urljoin
 
 import requests
@@ -52,55 +52,91 @@ def _fetch(session: Session, url: str, settings: Settings) -> Response:
 
 def iter_api_posts(session: Session, settings: Settings) -> Iterator[tuple[str, str]]:
     api_url = urljoin(settings.base_url, "/wp-json/wp/v2/posts")
-    page = 1
-    total_pages: int | None = None
     per_page = max(1, min(settings.posts_per_page, 100))
+    cached_pages: dict[int, list] = {}
+    cached_headers: dict[int, Mapping[str, str]] = {}
 
-    while True:
+    class PaginationComplete(Exception):
+        """Raised when the API indicates there are no more pages."""
+
+    def fetch_page(page: int) -> list:
         params = {
             "page": page,
             "per_page": per_page,
             "orderby": "date",
-            "order": "asc",
+            "order": "desc",
             "_fields": "link,title.rendered",
         }
+        response = session.get(api_url, params=params, timeout=settings.request_timeout)
+        if response.status_code == 400:
+            raise PaginationComplete
+        response.raise_for_status()
         try:
-            response = session.get(api_url, params=params, timeout=settings.request_timeout)
-            if response.status_code == 400:
-                logger.warning("Reached end of available posts at page %s", page)
-                break
-            response.raise_for_status()
-        except requests.RequestException as exc:
-            logger.warning("Stopping pagination at page %s due to error: %s", page, exc)
-            break
-
-        try:
-            items = response.json()
+            payload = response.json()
         except ValueError as exc:
-            logger.warning("Invalid JSON payload on page %s: %s", page, exc)
-            break
+            raise ValueError(f"Invalid JSON payload on page {page}: {exc}") from exc
+        if not isinstance(payload, list):
+            raise ValueError(f"Unexpected JSON payload on page {page}: {payload!r}")
+        cached_pages[page] = payload
+        cached_headers[page] = response.headers
+        return payload
+
+    try:
+        fetch_page(1)
+    except PaginationComplete:
+        logger.info("No posts returned by the API")
+        return
+    except requests.RequestException as exc:
+        logger.warning("Stopping pagination at page 1 due to error: %s", exc)
+        return
+    except ValueError as exc:
+        logger.warning("%s", exc)
+        return
+
+    header_total: int | None = None
+    try:
+        headers = cached_headers.get(1)
+        if headers is not None:
+            header_total = int(headers.get("X-WP-TotalPages", ""))
+    except (ValueError, TypeError):
+        header_total = None
+
+    if header_total is None:
+        total_pages = settings.total_pages if settings.total_pages > 0 else 1
+    else:
+        total_pages = header_total
+
+    if settings.total_pages > 0:
+        total_pages = min(total_pages, settings.total_pages)
+
+    total_pages = max(1, total_pages)
+
+    for page in range(total_pages, 0, -1):
+        if page in cached_pages:
+            items = cached_pages[page]
+        else:
+            try:
+                items = fetch_page(page)
+            except PaginationComplete:
+                logger.warning("Reached end of available posts at page %s", page)
+                continue
+            except requests.RequestException as exc:
+                logger.warning("Stopping pagination at page %s due to error: %s", page, exc)
+                break
+            except ValueError as exc:
+                logger.warning("%s", exc)
+                continue
 
         if not items:
-            break
+            continue
 
-        for item in items:
+        for item in reversed(items):
             link = (item.get("link") or "").strip()
             title_html = item.get("title", {}).get("rendered", "")
             title = BeautifulSoup(title_html, "html.parser").get_text(" ", strip=True)
             if not link:
                 continue
             yield (title or link, link)
-
-        if total_pages is None:
-            try:
-                total_pages = int(response.headers.get("X-WP-TotalPages", ""))
-            except (TypeError, ValueError):
-                total_pages = None
-
-        if total_pages is not None and page >= total_pages:
-            break
-
-        page += 1
 
 
 def extract_images(session: Session, url: str, settings: Settings) -> list[str]:

--- a/src/hemmatco_scraper/state.py
+++ b/src/hemmatco_scraper/state.py
@@ -46,5 +46,12 @@ class State:
         self.load()
         return set(self._processed)
 
+    def clear(self) -> None:
+        """Forget every processed URL and persist the empty state."""
+
+        self._processed = set()
+        self._loaded = True
+        self.save()
+
 
 __all__ = ["State"]


### PR DESCRIPTION
## Summary
- update the scraper pagination logic to walk the WordPress API from the oldest page to the newest so messages go out chronologically
- add a RESET_STATE flag, workflow input, and documentation so manual runs can resend every post from scratch for testing
- clear the cached state when requested and describe the behaviour in the README

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68d7da5eb3ac8325a4be7a4189b16934