### PR TITLE
Send Telegram posts without links and attach photos

### DIFF
--- a/src/hemmatco_scraper/main.py
+++ b/src/hemmatco_scraper/main.py
@@ -6,17 +6,14 @@ from typing import Iterable
 from .config import Settings
 from .scraper import Post, collect_new_posts, create_session, sleep_between_posts
 from .state import State
-from .telegram import send_messages
+from .telegram import send_messages, send_photos
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
 logger = logging.getLogger(__name__)
 
 
 def format_post(post: Post) -> Iterable[str]:
-    header = f"📌 {post.title}\n{post.url}"
-    yield header
-    for index, image_url in enumerate(post.image_urls, start=1):
-        yield f"{index}. {image_url}"
+    yield f"📌 {post.title}"
 
 
 def dispatch_posts(settings: Settings, posts: list[Post], state: State) -> None:
@@ -42,7 +39,13 @@ def dispatch_posts(settings: Settings, posts: list[Post], state: State) -> None:
                 settings.telegram_topic_id,
                 format_post(post),
             )
-            logger.info("Sent %s with %s image link(s)", post.url, len(post.image_urls))
+            send_photos(
+                settings.telegram_token,
+                settings.telegram_chat_id,
+                settings.telegram_topic_id,
+                post.image_urls,
+            )
+            logger.info("Sent %s with %s image(s)", post.url, len(post.image_urls))
         state.mark_processed([post.url])
         state.save()
         logger.info("Recorded %s as processed", post.url)

--- a/src/hemmatco_scraper/telegram.py
+++ b/src/hemmatco_scraper/telegram.py
@@ -55,4 +55,31 @@ def send_messages(
         logger.info("Sent message %s/%s to Telegram", index + 1, len(payloads))
 
 
-__all__ = ["send_messages"]
+def send_photos(
+    token: str,
+    chat_id: str,
+    topic_id: Optional[int],
+    image_urls: Iterable[str],
+) -> None:
+    photos = list(image_urls)
+    if not photos:
+        return
+    total = len(photos)
+    for index, image_url in enumerate(photos, start=1):
+        data = {
+            "chat_id": chat_id,
+            "photo": image_url,
+        }
+        if topic_id is not None:
+            data["message_thread_id"] = topic_id
+        url = f"{API_BASE}/bot{token}/sendPhoto"
+        response = requests.post(url, data=data, timeout=60)
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.error("Telegram API error while sending photo: %s", response.text)
+            raise
+        logger.info("Sent photo %s/%s to Telegram", index, total)
+
+
+__all__ = ["send_messages", "send_photos"]


### PR DESCRIPTION
## Summary
- update the post formatter to emit only the title header without the article URL
- send each post image to Telegram via sendPhoto so photos appear instead of plain links

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68d7df4744dc832592f8e369160fd418