### PR TITLE
Handle Telegram rate limits and improve photo quality

### DIFF
--- a/src/hemmatco_scraper/main.py
+++ b/src/hemmatco_scraper/main.py
@@ -44,6 +44,7 @@ def dispatch_posts(settings: Settings, posts: list[Post], state: State) -> None:
                 settings.telegram_chat_id,
                 settings.telegram_topic_id,
                 post.image_urls,
+                download_headers={"User-Agent": settings.user_agent},
             )
             logger.info("Sent %s with %s image(s)", post.url, len(post.image_urls))
         state.mark_processed([post.url])

--- a/src/hemmatco_scraper/scraper.py
+++ b/src/hemmatco_scraper/scraper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import Iterable, Iterator, List, Mapping
+from typing import Iterable, Iterator, List, Mapping, Tuple
 from urllib.parse import urljoin
 
 import requests
@@ -139,6 +139,65 @@ def iter_api_posts(session: Session, settings: Settings) -> Iterator[tuple[str, 
             yield (title or link, link)
 
 
+def _parse_srcset(value: str) -> list[Tuple[str, float]]:
+    candidates: list[Tuple[str, float]] = []
+    for item in value.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        parts = item.split()
+        if not parts:
+            continue
+        source = parts[0]
+        descriptor = parts[1] if len(parts) > 1 else ""
+        score = 0.0
+        if descriptor.endswith("w"):
+            try:
+                score = float(descriptor[:-1])
+            except ValueError:
+                score = 0.0
+        elif descriptor.endswith("x"):
+            try:
+                score = float(descriptor[:-1]) * 1000
+            except ValueError:
+                score = 0.0
+        candidates.append((source, score))
+    return candidates
+
+
+def _select_best_image(img, base_url: str) -> str | None:
+    priority_sources: list[Tuple[str, float]] = []
+    for attr in (
+        "data-full-image",
+        "data-full_image",
+        "data-large_image",
+        "data-large_image_url",
+        "data-original",
+        "data-orig-file",
+    ):
+        value = (img.get(attr) or "").strip()
+        if value:
+            priority_sources.append((urljoin(base_url, value), 1_000_000.0))
+
+    for attr in ("data-srcset", "data-src-set", "srcset"):
+        value = img.get(attr)
+        if not value:
+            continue
+        for source, score in _parse_srcset(value):
+            priority_sources.append((urljoin(base_url, source), score))
+
+    for attr in ("data-src", "data-lazy-src", "src"):
+        value = (img.get(attr) or "").strip()
+        if value:
+            priority_sources.append((urljoin(base_url, value), -1.0))
+
+    if not priority_sources:
+        return None
+
+    best_url, _ = max(priority_sources, key=lambda item: item[1])
+    return best_url
+
+
 def extract_images(session: Session, url: str, settings: Settings) -> list[str]:
     response = _fetch(session, url, settings)
     soup = BeautifulSoup(response.text, "html.parser")
@@ -152,10 +211,10 @@ def extract_images(session: Session, url: str, settings: Settings) -> list[str]:
 
     def append_images(elements: Iterable) -> None:
         for img in elements:
-            src = img.get("data-src") or img.get("data-lazy-src") or img.get("src")
-            if not src:
+            best = _select_best_image(img, url)
+            if not best:
                 continue
-            absolute = urljoin(url, src.strip())
+            absolute = best.strip()
             if absolute in seen:
                 continue
             seen.add(absolute)

--- a/src/hemmatco_scraper/telegram.py
+++ b/src/hemmatco_scraper/telegram.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import logging
+import mimetypes
+import os
+import time
 from typing import Iterable, Optional
+from urllib.parse import unquote, urlparse
 
 import requests
 
@@ -9,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 API_BASE = "https://api.telegram.org"
 MESSAGE_LIMIT = 4000
+DEFAULT_RETRY_DELAY = 5
+TELEGRAM_TIMEOUT = 30
 
 
 def chunk_lines(lines: Iterable[str], limit: int = MESSAGE_LIMIT) -> list[str]:
@@ -29,6 +35,41 @@ def chunk_lines(lines: Iterable[str], limit: int = MESSAGE_LIMIT) -> list[str]:
     return chunks
 
 
+def _extract_retry_after(response: requests.Response) -> int:
+    try:
+        payload = response.json()
+    except ValueError:
+        return DEFAULT_RETRY_DELAY
+
+    if isinstance(payload, dict):
+        retry_after = payload.get("retry_after")
+        parameters = payload.get("parameters")
+        if isinstance(parameters, dict) and retry_after is None:
+            retry_after = parameters.get("retry_after")
+        try:
+            if retry_after is not None:
+                retry_value = int(retry_after)
+                if retry_value > 0:
+                    return retry_value
+        except (TypeError, ValueError):
+            pass
+    return DEFAULT_RETRY_DELAY
+
+
+def _post_telegram(url: str, *, timeout: int = TELEGRAM_TIMEOUT, **kwargs) -> requests.Response:
+    while True:
+        response = requests.post(url, timeout=timeout, **kwargs)
+        if response.status_code != 429:
+            return response
+        delay = _extract_retry_after(response)
+        logger.warning(
+            "Telegram rate limit encountered for %s; sleeping %s second(s) before retrying",
+            url,
+            delay,
+        )
+        time.sleep(max(1, delay))
+
+
 def send_messages(
     token: str,
     chat_id: str,
@@ -46,7 +87,7 @@ def send_messages(
         if topic_id is not None:
             data["message_thread_id"] = topic_id
         url = f"{API_BASE}/bot{token}/sendMessage"
-        response = requests.post(url, json=data, timeout=30)
+        response = _post_telegram(url, json=data)
         try:
             response.raise_for_status()
         except requests.HTTPError:
@@ -60,26 +101,67 @@ def send_photos(
     chat_id: str,
     topic_id: Optional[int],
     image_urls: Iterable[str],
+    *,
+    download_headers: Optional[dict[str, str]] = None,
+    download_timeout: int = 60,
 ) -> None:
     photos = list(image_urls)
     if not photos:
         return
     total = len(photos)
     for index, image_url in enumerate(photos, start=1):
+        try:
+            filename, content_type, payload = _download_image(
+                image_url,
+                headers=download_headers,
+                timeout=download_timeout,
+            )
+        except requests.RequestException as exc:
+            logger.error("Failed to download %s: %s", image_url, exc)
+            raise
+
         data = {
             "chat_id": chat_id,
-            "photo": image_url,
         }
         if topic_id is not None:
             data["message_thread_id"] = topic_id
+        files = {
+            "photo": (filename, payload, content_type or "application/octet-stream"),
+        }
         url = f"{API_BASE}/bot{token}/sendPhoto"
-        response = requests.post(url, data=data, timeout=60)
+        response = _post_telegram(url, data=data, files=files, timeout=download_timeout)
         try:
             response.raise_for_status()
         except requests.HTTPError:
             logger.error("Telegram API error while sending photo: %s", response.text)
             raise
         logger.info("Sent photo %s/%s to Telegram", index, total)
+
+
+def _download_image(
+    url: str,
+    *,
+    headers: Optional[dict[str, str]] = None,
+    timeout: int,
+) -> tuple[str, Optional[str], bytes]:
+    response = requests.get(url, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    content_type = response.headers.get("Content-Type")
+    filename = _infer_filename(url, content_type)
+    return filename, content_type, response.content
+
+
+def _infer_filename(url: str, content_type: Optional[str]) -> str:
+    parsed = urlparse(url)
+    candidate = unquote(os.path.basename(parsed.path))
+    if not candidate:
+        candidate = "photo"
+    if "." not in candidate and content_type:
+        mime = content_type.split(";", 1)[0].strip()
+        extension = mimetypes.guess_extension(mime)
+        if extension:
+            candidate = f"{candidate}{extension}"
+    return candidate
 
 
 __all__ = ["send_messages", "send_photos"]


### PR DESCRIPTION
## Summary
- add automatic retry logic that honours Telegram API retry_after values to avoid rate limit failures
- download post images and upload them as Telegram photos while inferring filenames and content types
- extract the highest-resolution image URLs from each post and reuse the scraper user agent when downloading

## Testing
- python -m compileall src/hemmatco_scraper

------
https://chatgpt.com/codex/tasks/task_b_68d7e4fa57a483259183799868a539ae